### PR TITLE
fix: initialize timestamp values with first value for delta computation

### DIFF
--- a/decoder/decode.go
+++ b/decoder/decode.go
@@ -112,9 +112,9 @@ func traverseDocElem(attribsList *[]string, attribsMap *map[string][]uint64, doc
 		}
 	case primitive.Timestamp:
 		tKey := parentPath + "/t"
-		addAttribute(attribsList, attribsMap, tKey, uint64(0), sliceCap)
+		addAttribute(attribsList, attribsMap, tKey, uint64(value.T), sliceCap)
 		iKey := parentPath + "/i"
-		addAttribute(attribsList, attribsMap, iKey, uint64(0), sliceCap)
+		addAttribute(attribsList, attribsMap, iKey, uint64(value.I), sliceCap)
 	case primitive.ObjectID: // ignore it
 	case string: // ignore it
 	case float64:


### PR DESCRIPTION
Initialize the timestamp `T` an `I` correctly as the first value for delta computation. 

Currently, the values are initialized with 0 leading to unsigned underflow resulting in parse errors. 